### PR TITLE
Convert to Salesforce DX Pilot and the sfdx CLI

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -95,17 +95,17 @@ mkdir -p $BUILD_DIR/.profile.d
 cat <<EOF >$BUILD_DIR/.profile.d/salesforce-env.sh
 
 # set path so release and customer scripts and use heroku cli
-export PATH="\$PATH:\$HOME/$VENDORED_HEROKU_CLI/heroku/bin"
+export PATH="\$PATH:\$HOME/$VENDORED_SFDX_CLI/heroku/bin"
 # set so heroku cli can re-use plugins
 export XDG_DATA_HOME="\$HOME/.local"
 # set so heroku cli can see heroku/autoupdate to not trigger update
 export XDG_CACHE_HOME="\$HOME/.cache"
 # set node path to shared modules
 
-# log SALESFORCE_ and HEROKU_ config vars
+# log SALESFORCE_ and SFDX_ config vars
 if [ "\$SALESFORCE_BUILDPACK_DEBUG" == "true" ]; then
     echo "[DEBUG] PATH=\$PATH"
-    for e in \$(env | grep '^SALESFORCE_\|^HEROKU_\|^APPCLOUD_\|^XDG_\|^NODE_'); do
+    for e in \$(env | grep '^SALESFORCE_\|^SFDX_\|^APPCLOUD_\|^XDG_\|^NODE_'); do
         echo "[DEBUG] \$e"
     done
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -110,6 +110,7 @@ if [ "\$SALESFORCE_BUILDPACK_DEBUG" == "true" ]; then
     done
 fi
 # setup env to support sfdx commands
+mkdir -p .sfdx
 mkdir -p .local/.sfdx
 
 echo "\$SFDX_HUB_ORG" > $HOME/.local/.sfdx/${SFDX_HUB_ORG_USERNAME}.json

--- a/bin/compile
+++ b/bin/compile
@@ -113,7 +113,6 @@ fi
 mkdir -p .local/.sfdx
 
 echo "\$SFDX_HUB_ORG" > $HOME/.local/.sfdx/${SFDX_HUB_ORG_USERNAME}.json
-echo "\$SFDX_CONFIG" > $HOME/.local/.appcloud/workspace_config.json
 echo '{ "defaultdevhubusername": "'$SFDX_HUB_ORG_USERNAME'" }' > $HOME/.local/sfdx/sfdx-config.json
 
 EOF

--- a/bin/compile
+++ b/bin/compile
@@ -43,41 +43,49 @@ mkdir -p $SALESFORCE_DIR
 export SALESFORCE_DIR=$SALESFORCE_DIR
 
 
-###   H E R O K U   C L I
-status "Installing Heroku CLI and SFDX plugins"
+###   S F D X   C L I
+status "Installing SFDX CLI and SFDX plugins"
 
 # vendor directories
-VENDORED_HEROKU_CLI="vendor/heroku-cli"
+VENDORED_SFDX_CLI="vendor/sfdx-cli"
 
 # download and extract the client tarball
-rm -rf "$BUILD_DIR/$VENDORED_HEROKU_CLI"
-mkdir -p "$BUILD_DIR/$VENDORED_HEROKU_CLI"
-cd "$BUILD_DIR/$VENDORED_HEROKU_CLI"
+rm -rf "$BUILD_DIR/$VENDORED_SFDX_CLI"
 
-: ${HEROKU_CLI_VERSION:="5.4.3-a5b1cb1"}
-HEROKU_CLI_URL="https://cli-assets.heroku.com/branches/stable/$HEROKU_CLI_VERSION/heroku-v$HEROKU_CLI_VERSION-linux-amd64.tar.xz"
+# install sfdx cli w/ all sfdx plugins
+cd "$BUILD_DIR"
+: ${SFDX_CLI_VERSION:="LATEST"}
+SFDX_CLI_URL=https://developer.salesforce.com/media/salesforce-cli/sfdx-buildpack-${SFDX_CLI_VERSION}.tar.gz
 if [ "$SALESFORCE_BUILDPACK_DEBUG" == "true" ]; then
-    debug "HEROKU_CLI_URL=$HEROKU_CLI_URL"
+    debug "SFDX_CLI_URL=$SFDX_CLI_URL"
 fi
 if [[ -z "$(which wget)" ]]; then
-  curl -s $HEROKU_CLI_URL | tar xJf -
+  curl -s $SFDX_CLI_URL | tar xzf -
 else
-  wget -qO- $HEROKU_CLI_URL | tar xJf -
+  wget -qO- $SFDX_CLI_URL | tar xzf -
 fi
 
-export PATH="$PATH:$BUILD_DIR/$VENDORED_HEROKU_CLI/heroku/bin"
+export PATH="$PATH:$BUILD_DIR/$VENDORED_SFDX_CLI/heroku/bin"
 export XDG_DATA_HOME="$BUILD_DIR/.local"
 export XDG_CACHE_HOME="$BUILD_DIR/.cache"
+
+if [ "$SALESFORCE_BUILDPACK_DEBUG" == "true" ]; then
+    debug $BUILD_DIR/$VENDORED_SFDX_CLI/heroku/bin:
+    ls -Llsrt $BUILD_DIR/$VENDORED_SFDX_CLI/heroku/bin
+fi
 
 # touch autoupdate file to prevent 'heroku update' (which breaks
 # tar as 'heroku update' alters what is being tar'd)
 mkdir -p $XDG_CACHE_HOME/heroku
 touch $XDG_CACHE_HOME/heroku/autoupdate
 
-heroku plugins:install force-com@pilot
-heroku plugins
+# log installed plugins
+sfdx plugins
 
-status "Heroku CLI and SFDX plugins installation complete"
+status "SFDX CLI and SFDX plugins installation complete"
+
+
+
 
 ###   W R I T E   E N V   P R O F I L E   S C R I P T
 # write env script to set various vars so release and test scripts
@@ -101,11 +109,12 @@ if [ "\$SALESFORCE_BUILDPACK_DEBUG" == "true" ]; then
         echo "[DEBUG] \$e"
     done
 fi
-# setup env to support appcloud and force.com plugin commands
-mkdir -p .local/.appcloud
+# setup env to support sfdx commands
+mkdir -p .local/.sfdx
 
-echo "\$SFDX_HUB_ORG" > $HOME/.local/.appcloud/hubOrg.json
+echo "\$SFDX_HUB_ORG" > $HOME/.local/.sfdx/${SFDX_HUB_ORG_USERNAME}.json
 echo "\$SFDX_CONFIG" > $HOME/.local/.appcloud/workspace_config.json
+echo '{ "defaultdevhubusername": "'$SFDX_HUB_ORG_USERNAME'" }' > $HOME/.local/sfdx/sfdx-config.json
 
 EOF
 
@@ -119,7 +128,7 @@ fi
 ###   F I N A L   N O T E S
 highlight "    "
 highlight "### N O T E ###"
-highlight "Heroku CLI and SFDX plugins are installed."
+highlight "SFDX CLI is installed."
 highlight "###############"
 highlight "    "
 

--- a/bin/compile
+++ b/bin/compile
@@ -113,7 +113,7 @@ fi
 mkdir -p .local/.sfdx
 
 echo "\$SFDX_HUB_ORG" > $HOME/.local/.sfdx/${SFDX_HUB_ORG_USERNAME}.json
-echo '{ "defaultdevhubusername": "'$SFDX_HUB_ORG_USERNAME'" }' > $HOME/.local/.sfdx/sfdx-config.json
+echo '{ "defaultdevhubusername": "'$SFDX_HUB_ORG_USERNAME'" }' > $HOME/.sfdx/sfdx-config.json
 
 EOF
 

--- a/bin/compile
+++ b/bin/compile
@@ -113,7 +113,7 @@ fi
 mkdir -p .local/.sfdx
 
 echo "\$SFDX_HUB_ORG" > $HOME/.local/.sfdx/${SFDX_HUB_ORG_USERNAME}.json
-echo '{ "defaultdevhubusername": "'$SFDX_HUB_ORG_USERNAME'" }' > $HOME/.local/sfdx/sfdx-config.json
+echo '{ "defaultdevhubusername": "'$SFDX_HUB_ORG_USERNAME'" }' > $HOME/.local/.sfdx/sfdx-config.json
 
 EOF
 

--- a/bin/compile
+++ b/bin/compile
@@ -102,6 +102,9 @@ export XDG_DATA_HOME="\$HOME/.local"
 export XDG_CACHE_HOME="\$HOME/.cache"
 # set node path to shared modules
 
+# disable encryption cause lib secret requires head
+export SFDX_DISABLE_ENCRYPTION=true;
+
 # log SALESFORCE_ and SFDX_ config vars
 if [ "\$SALESFORCE_BUILDPACK_DEBUG" == "true" ]; then
     echo "[DEBUG] PATH=\$PATH"


### PR DESCRIPTION
Makes the `sfdx` command available and authenticated:

Requires new environment variable `SFDX_HUB_ORG_USERNAME`