### PR TITLE
Set signupTargetLoginUrl based on SF_SANDBOX_LOGIN_URL

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -123,6 +123,10 @@ if [ "\$SFDX_LOGIN_URL" == "" ]; then
 else
     sfdx force:auth:jwt:grant -d -a DevHub -i "\$SFDX_CLIENT_ID" -f \$HOME/.local/.sfdx_server.key -u \$SFDX_HUB_USERNAME -r \$SFDX_LOGIN_URL
 fi
+
+if [ -n "\$SF_SANDBOX_LOGIN_URL" ]; then
+    echo "{\"signupTargetLoginUrl\": \"\$SF_SANDBOX_LOGIN_URL\" }" > .sfdx/sfdx-project.json
+fi
 EOF
 
 chmod +x $BUILD_DIR/.profile.d/salesforce-env.sh


### PR DESCRIPTION
I think this will help make sure sfdx hits the right endpoint to complete oauth for the scratch org, but my bash is rusty.

The idea that this can be inherited from .sfdx/sfdx-project.json comes from https://github.com/forcedotcom/salesforce-alm/blob/master/src/lib/core/configApi.ts#L279