### PR TITLE
Pin to older version of the salesforce-alm plugin 

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -72,6 +72,8 @@ touch $XDG_CACHE_HOME/sfdx/autoupdate
 
 # update sfdx
 sfdx update
+# temporary workaround for scratch org regression in 52.2.2
+sfdx plugins:install salesforce-alm@52.1.0
 
 # log installed plugins
 sfdx plugins --core


### PR DESCRIPTION
(to work around an issue with creating scratch orgs outside a project)