### PR TITLE
Only try to run sfdx force:auth:jwt:grant if SFDX_CLIENT_ID and SFDX_HUB_USERNAME were specified

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -109,10 +109,12 @@ ln -s /app/.local/.sfdx /app/.local/.appcloud
 
 echo "\$SFDX_HUB_KEY" > \$HOME/.local/.sfdx_server.key
 
-if [ "\$SFDX_LOGIN_URL" == "" ]; then
-    sfdx force:auth:jwt:grant -d -a DevHub -i "\$SFDX_CLIENT_ID" -f \$HOME/.local/.sfdx_server.key -u \$SFDX_HUB_USERNAME
-else
-    sfdx force:auth:jwt:grant -d -a DevHub -i "\$SFDX_CLIENT_ID" -f \$HOME/.local/.sfdx_server.key -u \$SFDX_HUB_USERNAME -r \$SFDX_LOGIN_URL
+if [[ -n "$SFDX_CLIENT_ID" && -n "$SFDX_HUB_USERNAME ]]; then
+    if [ "\$SFDX_LOGIN_URL" == "" ]; then
+        sfdx force:auth:jwt:grant -d -a DevHub -i "\$SFDX_CLIENT_ID" -f \$HOME/.local/.sfdx_server.key -u \$SFDX_HUB_USERNAME
+    else
+        sfdx force:auth:jwt:grant -d -a DevHub -i "\$SFDX_CLIENT_ID" -f \$HOME/.local/.sfdx_server.key -u \$SFDX_HUB_USERNAME -r \$SFDX_LOGIN_URL
+    fi
 fi
 
 if [ -n "\$SF_SANDBOX_LOGIN_URL" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -111,9 +111,9 @@ echo "\$SFDX_HUB_KEY" > \$HOME/.local/.sfdx_server.key
 
 if [[ -n "$SFDX_CLIENT_ID" && -n "$SFDX_HUB_USERNAME ]]; then
     if [ "\$SFDX_LOGIN_URL" == "" ]; then
-        sfdx force:auth:jwt:grant -d -a DevHub -i "\$SFDX_CLIENT_ID" -f \$HOME/.local/.sfdx_server.key -u \$SFDX_HUB_USERNAME
+        sfdx auth:jwt:grant -d -a DevHub -i "\$SFDX_CLIENT_ID" -f \$HOME/.local/.sfdx_server.key -u \$SFDX_HUB_USERNAME
     else
-        sfdx force:auth:jwt:grant -d -a DevHub -i "\$SFDX_CLIENT_ID" -f \$HOME/.local/.sfdx_server.key -u \$SFDX_HUB_USERNAME -r \$SFDX_LOGIN_URL
+        sfdx auth:jwt:grant -d -a DevHub -i "\$SFDX_CLIENT_ID" -f \$HOME/.local/.sfdx_server.key -u \$SFDX_HUB_USERNAME -r \$SFDX_LOGIN_URL
     fi
 fi
 


### PR DESCRIPTION
Avoids `ERROR running auth:jwt:grant:  Flag --username expects a value` when the buildpack is being used to install sfdx without authorizing a dev hub.