### PR TITLE
Skip updating sfdx

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -70,9 +70,6 @@ fi
 mkdir -p $XDG_CACHE_HOME/sfdx
 touch $XDG_CACHE_HOME/sfdx/autoupdate
 
-# update sfdx
-sfdx update stable-rc
-
 # log installed plugins
 sfdx plugins --core
 


### PR DESCRIPTION
My hypothesis is that this will avoid including 2 copies of sfdx in the slug